### PR TITLE
Fix broken gts/gjs hot reload (after landing rfc931)

### DIFF
--- a/plugins/gts-resolver.js
+++ b/plugins/gts-resolver.js
@@ -4,37 +4,17 @@ const p = new Preprocessor();
 const fileRegex = /\.(gts|gjs)$/;
 
 function tpl(raw, id) {
-  const result = p.process(raw, id);
-  // console.log(result);
-  return result;
-  //result.output.replace('strictMode: true', 'isStrictMode: true');
+  return p.process(raw, id);
 }
 
-function hotLoad(id) {
-  return `
-  if (import.meta.hot) {
-    import.meta.hot.accept((newModule) => {
-      const moduleName = '${id}';
-      window.dispatchEvent(
-        new CustomEvent('hot-reload', {
-          detail: {
-            moduleName,
-            component: newModule.default,
-          },
-        })
-      );
-    });
-  }`;
-}
-
-export default function hbsResolver(isProd) {
+export default function hbsResolver() {
   return {
     name: 'gts-resolver',
     enforce: 'pre',
     transform(src, id) {
       if (fileRegex.test(id, id)) {
         return {
-          code: isProd ? tpl(src, id) : tpl(src, id) + hotLoad(id),
+          code: tpl(src, id),
           map: null, // provide source map if available
         };
       }

--- a/plugins/hot-reload.ts
+++ b/plugins/hot-reload.ts
@@ -8,7 +8,12 @@ type SeenElement = ASTv1.ElementNode & { [Seen]?: boolean };
 
 const HotComponentName = 'Hot';
 const HotComponentAttribute = '@component';
-const PrecompileFunctionName = 'precompileTemplate';
+const HotComponentPath = '@/components/Hot';
+const PrecompileFunctionNames = [
+  'precompileTemplate',
+  'compileTemplate',
+  'template',
+];
 const ScopePropertyName = 'scope';
 const WindowHotReloadEventName = 'hot-reload';
 
@@ -42,12 +47,14 @@ function elementTransform(node: SeenElement, scopeKeys: string[]) {
 }
 
 function shouldProcess(fileName: string) {
+  const isHotComponent = fileName.includes('/components/Hot');
   const isSrcFile = fileName.includes('/src/');
   const isNodeModules = fileName.includes('/node_modules/');
   const isTestFile = fileName.includes('/tests/');
   const isComponentFile = fileName.includes('/components/');
   const isTemplate = fileName.includes('/templates/');
   return (
+    !isHotComponent &&
     isSrcFile &&
     !isNodeModules &&
     !isTestFile &&
@@ -70,6 +77,15 @@ function hasImportDeclaration(node: babelTypes.Program) {
   });
 }
 
+function hasImportedHotComponent(node: babelTypes.Program) {
+  return node.body.find((node) => {
+    return (
+      node.type === 'ImportDeclaration' &&
+      node.source.value === HotComponentPath
+    );
+  });
+}
+
 function hasImportMetaHot(node: babelTypes.Program) {
   return node.body.find((node) => {
     return (
@@ -84,20 +100,31 @@ function hasImportMetaHot(node: babelTypes.Program) {
   });
 }
 
-export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
+export function babelHotReloadPlugin(babel: { types: typeof babelTypes }): {
+  visitor: Record<string, any>;
+} {
   // get file name
   const t = babel.types;
   let cnt = 0;
+  type State = {
+    shouldProcess: boolean;
+    file: { opts: { filename?: string } };
+    moduleName: string;
+    sourcesToHotReload: Set<string>;
+  };
+  interface Path<T> {
+    node: T;
+  }
   const visitor = {
     Program: {
-      enter(_: any, state: any) {
+      enter(_: Path<babelTypes.Program>, state: State) {
         const fileName = state.file.opts.filename || '';
 
         state.shouldProcess = shouldProcess(fileName);
         state.moduleName = '';
         state.sourcesToHotReload = new Set();
       },
-      exit(path: any, state: any) {
+      exit(path: Path<babelTypes.Program>, state: State) {
         if (!state.shouldProcess) {
           return;
         }
@@ -156,6 +183,7 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
         */
         // console.log('state.moduleName', state.moduleName);
         const hasImportMetaHotReload = hasImportMetaHot(path.node);
+        const hasImportedHot = hasImportedHotComponent(path.node);
         // console.log(hasImportMetaHotReload, state.file.opts.filename);
 
         /*
@@ -186,6 +214,14 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
             )
           ),
         ]);
+
+        !hasImportedHot &&
+          path.node.body.push(
+            t.importDeclaration(
+              [t.importDefaultSpecifier(t.identifier(HotComponentName))],
+              t.stringLiteral(HotComponentPath)
+            )
+          );
 
         !hasImportMetaHotReload &&
           path.node.body.push(
@@ -372,11 +408,12 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
               ])
             )
           );
-
-        // console.log(path.toString());
       },
     },
-    ExportDefaultDeclaration(path: any, state: any) {
+    ExportDefaultDeclaration(
+      path: Path<babelTypes.ExportDefaultDeclaration>,
+      state: State
+    ) {
       if (!state.shouldProcess) {
         return;
       }
@@ -385,7 +422,7 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
         state.moduleName = path.node.declaration.id.name;
       }
     },
-    ImportDeclaration(path: any, state: any) {
+    ImportDeclaration(path: Path<babelTypes.ImportDeclaration>, state: State) {
       if (!state.shouldProcess) {
         return;
       }
@@ -396,13 +433,23 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
         state.sourcesToHotReload.add(path.node.source.value);
       }
     },
-    CallExpression(path: any, state: any) {
+    CallExpression(path: Path<babelTypes.CallExpression>, state: State) {
       if (!state.shouldProcess) {
         return;
       }
-      if (path.node.callee.name !== PrecompileFunctionName) {
+      // if (state.file.opts.filename.endsWith('.gts')) {
+      //   // console.log(path.toString());
+      // }
+      if (!t.isIdentifier(path.node.callee)) {
+        // console.log('return', path.node.callee,  state.file.opts.filename);
         return;
       }
+      if (!PrecompileFunctionNames.includes(path.node.callee.name)) {
+        // console.log('return-2', path.node.callee.name, state.file.opts.filename);
+        return;
+      }
+
+      // console.log('continue', path.node.callee.name, state.file.opts.filename);
 
       let scopeKeys: string[] = [];
 
@@ -431,8 +478,18 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
           }
         }
       }
-
-      const tpl = path.node.arguments[0].quasis[0].value.raw;
+      let tpl = '';
+      const firstArg = path.node.arguments[0];
+      const isTemplateLiteral = t.isTemplateLiteral(firstArg);
+      const isStringLiteral = t.isStringLiteral(firstArg);
+      if (isTemplateLiteral && firstArg.quasis.length) {
+        const q = firstArg.quasis[0];
+        if (q) {
+          tpl = q.value.raw;
+        }
+      } else if (isStringLiteral) {
+        tpl = firstArg.value;
+      }
       const ast = preprocess(tpl);
       traverse(ast, {
         ElementNode(node: ASTv1.ElementNode) {
@@ -443,9 +500,13 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }) {
 
       const newTpl = print(ast);
 
-      path.node.arguments[0].quasis[0] = t.templateElement({
-        raw: newTpl,
-      });
+      if (isTemplateLiteral) {
+        firstArg.quasis[0] = t.templateElement({
+          raw: newTpl,
+        });
+      } else if (isStringLiteral) {
+        firstArg.value = newTpl;
+      }
     },
   };
   return { visitor };

--- a/plugins/hot-reload.ts
+++ b/plugins/hot-reload.ts
@@ -473,6 +473,15 @@ export function babelHotReloadPlugin(babel: { types: typeof babelTypes }): {
                       ''
                   )
                   .filter((e) => e && e.length) as string[];
+                // add Hot to scope
+                scope.value.body.properties.push(
+                  t.objectProperty(
+                    t.identifier(HotComponentName),
+                    t.identifier(HotComponentName),
+                    false,
+                    true
+                  )
+                );
               }
             }
           }

--- a/src/components/HelloWorld/sample.gts
+++ b/src/components/HelloWorld/sample.gts
@@ -6,5 +6,5 @@ function add(a: number, b: number) {
 }
 
 export default class MyComponent extends Component {
-    <template><Button>{{add 1 2}}</Button></template>
+    <template><Button>{{add 2 3}}</Button></template>
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,11 +72,6 @@ export default defineConfig(({ mode }) => {
       ENV_CI: false,
       ...generateDefineConfig(isProd),
     },
-    optimizeDeps: {
-      esbuildOptions: {
-        external: ['ember-template-compiler'],
-      },
-    },
     resolve: {
       extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.hbs'],
       alias: [
@@ -93,6 +88,11 @@ export default defineConfig(({ mode }) => {
         {
           find: 'ember-simple-auth/use-session-setup-method',
           replacement: './compat/ember-simple-auth/use-session-setup-method.ts',
+        },
+        {
+          find: 'ember-template-compiler',
+          replacement:
+            'node_modules/ember-source/dist/ember-template-compiler.js',
         },
         {
           find: /ember-simple-auth\/(?!(app|addon)\/)(.+)/,


### PR DESCRIPTION
Related to https://github.com/lifeart/demo-ember-vite/pull/57

Hot reload logic need to be updated because:
1. `precompileTemplate` not extended with `compileTemplate` and `template` functions
2. all mentioned functions may accept `StringLiteral` instead of `TemplateLiteral`
3. `gts/gjs` now really strict, including `template` and require `scope` to contain used components
4. according to `3` we adding import of `Hot` component to all cases, including `scope`
